### PR TITLE
16 parse init

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,15 +3,19 @@
 #
 # This Makefile manages:
 #  - Production Binary : $(NAME)
+#  - Archiver Library  : $(AR_NAME)
 #  - Debug Binary      : $(DEBUG_NAME)
 #  - Unit Test Suite   : $(TEST_NAME)
 ################################################################################
 
 NAME        = ft_parse
+AR_NAME     = ft_parse.a
 TEST_NAME   = ft_parse_t
 DEBUG_NAME  = ft_parse_d
 CC          = cc
 CFLAGS      = -Wall -Wextra -Werror
+AR          = ar
+ARFLAGS     = rcs
 INC_DIRS    = -I include -I src -I src/help -I src/input -I src/lib -I src/options
 
 SRC_DIR     = src
@@ -25,12 +29,13 @@ SRCS        = $(SRC_DIR)/main.c \
               $(SRC_DIR)/ft_parse.c \
               $(HELP_DIR)/parse_help.c \
               $(INPUT_DIR)/parse_input.c \
-              $(LIB_DIR)/parse_color.c \
-              $(OPTIONS_DIR)/parse_options_handler.c
+              $(LIB_DIR)/parse_color.c
+              
 
 TEST_SRCS   = $(SRC_DIR)/main.t.c \
               $(HELP_DIR)/parse_help.t.c \
-              $(INPUT_DIR)/parse_input.t.c
+              $(INPUT_DIR)/parse_input.t.c \
+			  $(OPTIONS_DIR)/parse_options_handler.c
 
 OBJS        = $(addprefix $(OBJ_DIR)/, $(notdir $(SRCS:.c=.o)))
 TEST_OBJS   = $(addprefix $(OBJ_DIR)/, $(notdir $(TEST_SRCS:.c=.o)))
@@ -73,6 +78,21 @@ all: $(NAME)
 
 $(NAME): $(OBJS)
 	@$(CC) $(CFLAGS) $(INC_DIRS) $^ -o $@
+	@echo "[SUCCESS] Production build standard sequence complete: $@"
+
+################################################################################
+# STEP: Static Library Archiver Configuration
+#
+# This section handles:
+#  - Archiving object files into a standalone static library (.a).
+#  - Filtering out the main object to ensure safe modular integration.
+################################################################################
+
+archiver: CFLAGS += -g
+archiver: clean $(AR_NAME)
+
+$(AR_NAME): $(OBJS_NO_MAIN)
+	@$(AR) $(ARFLAGS) $@ $^
 	@echo "[SUCCESS] Production build standard sequence complete: $@"
 
 ################################################################################
@@ -120,9 +140,9 @@ clean:
 	@echo "[CLEAN] Removed intermediate object files directory."
 
 fclean: clean
-	@$(RM) $(NAME) $(TEST_NAME) $(DEBUG_NAME)
+	@$(RM) $(NAME) $(AR_NAME) $(TEST_NAME) $(DEBUG_NAME) 
 	@echo "[FCLEAN] Purged all generated execution binaries."
 
 re: fclean all
 
-.PHONY: all test debug clean fclean re
+.PHONY: all archiver test debug clean fclean re

--- a/src/ft_parse.c
+++ b/src/ft_parse.c
@@ -2,10 +2,9 @@
 #include <stdlib.h>
 #include "ft_parse.h"
 #include "parse_input.h"
-#include "parse_options.h"
 
-int ft_parse(int argc, const char **argv) {
-    struct parse_input_item *parse_items = parse_input(argc, argv);
+int ft_parse(int argc, const char **argv, const struct parse_option options[]) {
+    struct parse_input_item *parse_items = parse_input(argc, argv, options);
     int remainder = 0;
 
     if (!parse_items)
@@ -20,7 +19,8 @@ int ft_parse(int argc, const char **argv) {
         }
         remainder = parse_items[i].option->handler(
             parse_items[i].arg_count,
-            parse_items[i].argv
+            parse_items[i].argv,
+            options
         );
         if (remainder) {
             if (remainder < 0 ) {
@@ -41,7 +41,8 @@ int ft_parse(int argc, const char **argv) {
     }
     parse_items[0].option->handler(
         parse_items[0].arg_count,
-        parse_items[0].argv
+        parse_items[0].argv,
+        options
     );
 
     free(parse_items);

--- a/src/ft_parse.h
+++ b/src/ft_parse.h
@@ -15,9 +15,10 @@ struct parse_option {
      * @brief Callback function pointer executed when the option is matched.
      * @param[in] ac   The argument count associated with this option.
      * @param[in] arg  The array of argument strings for this option.
+     * @param[in] options  Pointer to the contiguous array of parsing options, terminated by a sentinel node.
      * @return int     Remaining positional arguments, 0 on success, or negative on fatal error.
      */
-    int (*handler)(const int ac, const char **arg);
+    int (*handler)(const int ac, const char **arg, const struct parse_option *options);
 };
 
 /**
@@ -29,11 +30,12 @@ struct parse_option {
  *
  * @param[in] argc  Argument count from the program main entry point.
  * @param[in] argv  Array of argument strings from the program main entry point.
+ * @param[in] options  Pointer to the contiguous array of parsing options, terminated by a sentinel node.
  * @return int      Returns 0 on complete parsing success,
  * 1 if the baseline handler is missing,
  * 2 on a fatal option handler error, or
  * -1 on initial memory allocation failure.
  */
-int ft_parse(int argc, const char **argv);
+int ft_parse(int argc, const char **argv, const struct parse_option options[]);
 
 #endif

--- a/src/help/parse_help.c
+++ b/src/help/parse_help.c
@@ -49,7 +49,7 @@ void print_options(const struct parse_option *opts ,const struct parse_theme *th
     }
 }
 
-void print_help(const char *descript, const struct parse_option *opts, const struct parse_theme *theme) 
+void print_help(const struct parse_option *opts, const struct parse_theme *theme) 
 {
     if (!opts || !theme) {
         printf("NO Help option\n");
@@ -58,7 +58,7 @@ void print_help(const char *descript, const struct parse_option *opts, const str
     extern char *program_invocation_short_name;
 
     print_Usage(program_invocation_short_name, theme);
-    print_description(descript, theme);
+    print_description(opts[0].description, theme);
     print_options(opts,theme);
 
     printf("\n----------------------------------------------------------\n");

--- a/src/help/parse_help.h
+++ b/src/help/parse_help.h
@@ -31,6 +31,6 @@ void print_options(const struct parse_option *opts, const struct parse_theme *th
  * @param[in] opts          Pointer to the parse_option array.
  * @param[in] theme         Color theme configuration.
  */
-void print_help(const char *descript, const struct parse_option *opts, const struct parse_theme *theme);
+void print_help(const struct parse_option *opts, const struct parse_theme *theme);
 
 #endif  // PARSE_HELP_H_

--- a/src/help/parse_help.t.c
+++ b/src/help/parse_help.t.c
@@ -1,10 +1,10 @@
 #include <stdio.h>
 #include "parse_help.t.h"
 
-int test_parse_help(int argc, const char **argv) {
+int test_parse_help(int argc, const char **argv, const struct parse_option options[] ) {
     (void)argc;
     (void)argv;
-    print_help(DESCRIPTION , options, &DEFAULT_THEME);
+    print_help(options, &PARSE_DEFAULT_THEME);
     
     return 0;
 };

--- a/src/help/parse_help.t.h
+++ b/src/help/parse_help.t.h
@@ -2,7 +2,6 @@
 # define PARSE_HELP_T_H
 
 #include "parse_help.h"
-#include "parse_options.h"
 #include "parse_color.h"
 
 /**
@@ -13,9 +12,10 @@
  *
  * @param[in] ac  Argument count (typically matching argc from main).
  * @param[in] av  Array of argument strings (typically matching argv from main).
+ * @param[in] options  Pointer to the contiguous array of parsing options, terminated by a sentinel node.
  * @return int    Returns 0 on test success, or a non-zero error code on failure.
  */
-int test_parse_help(int ac, const char **av);
+int test_parse_help(int ac, const char **av, const struct parse_option options[] );
 
 #endif
 

--- a/src/input/parse_input.c
+++ b/src/input/parse_input.c
@@ -24,7 +24,7 @@ const struct parse_option *find_long_opt(const struct parse_option *opts, const 
     return NULL;
 }
 
-struct parse_input_item *parse_input(int argc, const char **argv) {
+struct parse_input_item *parse_input(int argc, const char **argv, const struct parse_option options[]) {
     struct parse_input_item *items = calloc(argc, sizeof(struct parse_input_item) + 1);
     int t = 0;
     const struct parse_option *option;
@@ -43,7 +43,7 @@ struct parse_input_item *parse_input(int argc, const char **argv) {
             else
                 option = find_short_opt(options, argv[i][1]);
             if (!option) {
-                print_help(DESCRIPTION, options, &DEFAULT_THEME);
+                print_help(options, &PARSE_DEFAULT_THEME);
                 return NULL;
             }
             items[t].option = option;

--- a/src/input/parse_input.h
+++ b/src/input/parse_input.h
@@ -2,7 +2,6 @@
 # define FT_PARSE_PARSE_INPUT_H
 
 #include "ft_parse.h"
-#include "parse_options.h"
 
 /**
  * @struct parse_input_item
@@ -35,11 +34,12 @@ const struct parse_option *find_long_opt(const struct parse_option *opts, const 
  * @brief Parses command-line arguments and maps them to their respective options.
  * @param[in] argc       Argument count from the main entry point.
  * @param[in] argv       Array of argument strings from the main entry point.
+ * @param[in] options  Pointer to the contiguous array of parsing options, terminated by a sentinel node.
  * @return struct parse_input_item* Dynamic array of parsed items, or NULL on memory allocation failure.
  * @note 
  * - The returned array is dynamically allocated and contains structured groups of options and arguments.
  * - Enforces rigorous error handling; terminates or reports error if an invalid option is encountered.
  */
-struct parse_input_item *parse_input(int argc, const char **argv);
+struct parse_input_item *parse_input(int argc, const char **argv, const struct parse_option options[]);
 
 #endif

--- a/src/input/parse_input.t.c
+++ b/src/input/parse_input.t.c
@@ -2,10 +2,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-int test_parse_input(int argc, const char **argv) {
+int test_parse_input(int argc, const char **argv, const struct parse_option options[] ) {
     printf("[TEST] Starting parse_input unit test...\n");
 
-    struct parse_input_item *parse_items = parse_input(argc, argv);
+    struct parse_input_item *parse_items = parse_input(argc, argv, options);
     
     if (!parse_items) {
         printf("[FAIL] parse_input returned NULL pointer.\n");

--- a/src/input/parse_input.t.h
+++ b/src/input/parse_input.t.h
@@ -11,8 +11,9 @@
  *
  * @param[in] argc  Argument count (typically matching argc from main).
  * @param[in] argv  Array of argument strings (typically matching argv from main).
+ * @param[in] options  Pointer to the contiguous array of parsing options, terminated by a sentinel node.
  * @return int      Returns 0 on all tests passing, or -1 if any validation fails.
  */
-int test_parse_input(int argc, const char **argv);
+int test_parse_input(int argc, const char **argv, const struct parse_option options[] );
 
-#endif  // FT_PARSE_PARSE_INPUT_T_H
+#endif

--- a/src/lib/parse_color.c
+++ b/src/lib/parse_color.c
@@ -1,6 +1,6 @@
 #include "parse_color.h"
 
-const struct parse_theme DEFAULT_THEME = {
+const struct parse_theme PARSE_DEFAULT_THEME = {
     .label = BOLD,
     .option = RESET,
     .desc = RESET,

--- a/src/lib/parse_color.h
+++ b/src/lib/parse_color.h
@@ -52,6 +52,6 @@ struct parse_theme {
     char *reset;      /**< The default reset sequence to close styled blocks. */
 };
 
-extern const struct parse_theme DEFAULT_THEME;
+extern const struct parse_theme PARSE_DEFAULT_THEME;
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -1,6 +1,13 @@
+
+#include <stddef.h>
 #include "ft_parse.h"
 
 int main(int ac, const char **av)
 {
-    return (ft_parse(ac,av));
+    const struct parse_option options[] = {
+        {0, NULL, NULL, "send ICMP ECHO_REQUEST to network hosts", NULL},
+        {0, NULL, NULL, NULL, NULL}
+    };
+
+    return (ft_parse(ac,av, options));
 }

--- a/src/main.t.c
+++ b/src/main.t.c
@@ -1,14 +1,24 @@
+#include <stddef.h>
 #include "ft_parse.h"
 #ifdef TEST_MODE
 # include "parse_help.t.h"
 # include "parse_input.t.h"
+# include "parse_options_handler.h"
 #endif
 
 int main(int ac, const char **av)
 {
+    const struct parse_option options[] = {
+        {0, NULL, NULL, "send ICMP ECHO_REQUEST to network hosts", handle_base},
+        {'v', "verbose", "Produce verbose output", NULL, handle_verbose},
+        {'c', "count",  "Stop after sending NUMBER packets", "ping -c 5 google.com", handle_count},
+        {'d', "debug", "Enable debug mode with extra logs", "ping --debug", NULL},
+        {'h', "help",  "Give this help list", "ping --help", handle_help},
+        {0, NULL, NULL, NULL, NULL}
+    };
 #ifdef TEST_MODE
-    // test_parse_help(ac, av);
-    test_parse_input(ac, av);
+    test_parse_help(ac, av, options);
+    test_parse_input(ac, av, options);
 #endif
     (void)ac;
     (void)av;

--- a/src/options/parse_options.h
+++ b/src/options/parse_options.h
@@ -9,8 +9,9 @@
  * @def DESCRIPTION
  * @brief Template program identification string. 
  * @note Replace this string with your specific application name and description.
+ * @deprecated This macro/variable has been commented out and is no longer used.
  */
-#define DESCRIPTION "FT_PING: A custom ping utility inspired by GNU inetutils."
+// #define DESCRIPTION = "FT_PING: A custom ping utility inspired by GNU inetutils.";
 
 /**
  * @brief Example layout array defining supported command-line options.
@@ -25,13 +26,13 @@
  * - **Index N-1 (Sentinel Node):** The array must be explicitly terminated 
  * with an empty structure `{0, NULL, NULL, NULL, NULL}` to safe-guard loop boundaries.
  */
-static const struct parse_option options[] = {
-    {0, NULL, NULL, "send ICMP ECHO_REQUEST to network hosts", handle_base},
-    {'v', "verbose", "Produce verbose output", NULL, handle_verbose},
-    {'c', "count",  "Stop after sending NUMBER packets", "ping -c 5 google.com", handle_count},
-    {'d', "debug", "Enable debug mode with extra logs", "ping --debug", NULL},
-    {'h', "help",  "Give this help list", "ping --help", handle_help},
-    {0, NULL, NULL, NULL, NULL}
-};
+// static const struct parse_option options[] = {
+//     {0, NULL, NULL, "send ICMP ECHO_REQUEST to network hosts", handle_base},
+//     {'v', "verbose", "Produce verbose output", NULL, handle_verbose},
+//     {'c', "count",  "Stop after sending NUMBER packets", "ping -c 5 google.com", handle_count},
+//     {'d', "debug", "Enable debug mode with extra logs", "ping --debug", NULL},
+//     {'h', "help",  "Give this help list", "ping --help", handle_help},
+//     {0, NULL, NULL, NULL, NULL}
+// };
 
 #endif

--- a/src/options/parse_options_handler.c
+++ b/src/options/parse_options_handler.c
@@ -2,12 +2,12 @@
 #include <stdlib.h>
 
 #include "parse_help.h"
-#include "parse_options.h"
 #include "parse_color.h"
 
-int handle_base(const int ac, const char **arg) {
+int handle_base(const int ac, const char **arg, const struct parse_option options[]) {
     (void)ac;
     (void)arg;
+    (void)options;
     printf("base function. ac : %d \n", ac);
     if (!arg) {
         printf("arg : is NULL in base! \n");
@@ -15,16 +15,18 @@ int handle_base(const int ac, const char **arg) {
     return ac;
 }
 
-int handle_help(const int ac, const char **arg) {
+int handle_help(const int ac, const char **arg, const struct parse_option options[]) {
     (void)ac;
     (void)arg;
-    print_help(DESCRIPTION , options, &DEFAULT_THEME);
+    (void)options;
+    print_help(options, &PARSE_DEFAULT_THEME);
     return -1;
 }
 
-int handle_verbose(const int ac, const char **arg) {
+int handle_verbose(const int ac, const char **arg, const struct parse_option options[]) {
     (void)ac;
     (void)arg;
+    (void)options;
     printf("Verbose mode enabled.\n");
 
     const char **port_str = arg;
@@ -40,8 +42,9 @@ int handle_verbose(const int ac, const char **arg) {
     return ac - 1;
 }
 
-int handle_count(const int ac, const char **arg) {
+int handle_count(const int ac, const char **arg, const struct parse_option options[]) {
     (void)ac;
+    (void)options;
     const char **port_str = arg;
     if (port_str) {
         printf("count set to: ");

--- a/src/options/parse_options_handler.h
+++ b/src/options/parse_options_handler.h
@@ -4,7 +4,6 @@
 #include "ft_parse.h"
 
 /**
- * @file parse_options_handler_example.h
  * @brief Template declarations for command-line option callback handlers.
  *
  * @details
@@ -22,21 +21,21 @@
 /**
  * @brief Baseline handler executed for remaining positional arguments (e.g., target host).
  */
-int handle_base(const int ac, const char **arg);
+int handle_base(const int ac, const char **arg, const struct parse_option options[]);
 
 /**
  * @brief Execution handler triggered by the help option.
  */
-int handle_help(const int ac, const char **arg);
+int handle_help(const int ac, const char **arg, const struct parse_option options[]);
 
 /**
  * @brief Execution handler triggered by the verbose option.
  */
-int handle_verbose(const int ac, const char **arg);
+int handle_verbose(const int ac, const char **arg, const struct parse_option options[]);
 
 /**
  * @brief Execution handler triggered by the count option.
  */
-int handle_count(const int ac, const char **arg);
+int handle_count(const int ac, const char **arg, const struct parse_option options[]);
 
 #endif


### PR DESCRIPTION
#16 Close

## Summary

- Changed insert parse_options in ft_parse param
- logic changed for using input parse_options
- make archiver makefile for using module

## Result

### Use Archiver

> [!Note]
> Create Makefile and makefile call archive command

```Makefile
…
FT_PARSE_DIR = ft_parse
LIB_PARSE    = $(FT_PARSE_DIR)/ft_parse.a
INC_DIRS     = -I $(FT_PARSE_DIR)/include -I $(FT_PARSE_DIR)/src
….
$(NAME): $(OBJS)
	@$(MAKE) -C $(FT_PARSE_DIR) archiver
	@$(CC) $(CFLAGS) $(OBJS) $(LIB_PARSE) -o $@
	@echo "[SUCCESS] Root build complete: ./$(NAME) is ready."
…
```

#### Make file example
```sh
$ make
make[1]: Entering directory '/home/kyoulee/Documents/projects/kyoulee/ft_parse'
[CLEAN] Removed intermediate object files directory.
[SUCCESS] Production build standard sequence complete: ft_parse.a
make[1]: Leaving directory '/home/kyoulee/Documents/projects/kyoulee/ft_parse'
[SUCCESS] Root build complete: ./test_parser is ready.
```

#### Test 

```sh
$ ./test_parser 
ft_parse result code: 0
```

```sh
$ ./test_parser -v
option is verbose 
[test.c] found option: Verbose Mode On!
[test.c] option is : -v
ft_parse result code: 0
```

```sh
$ ./test_parser -x 
[1mUsage[0m
  test_parser [[0mOPTION[0m...]

[1mDESCRIPTION[0m
  Baseline infrastructure layer

[1mOptions[0m
[0m  -v, --verbose               [0m [0mProduce verbose output[0m

----------------------------------------------------------
Report bugs to: <kyoulee@github.com>
ft_parse result code: -1
```
